### PR TITLE
Frontpage failure for javascript popups

### DIFF
--- a/skoleintra/pgFrontpage.py
+++ b/skoleintra/pgFrontpage.py
@@ -105,6 +105,8 @@ def skoleNewsFrom(bss):
         href = bs.a['href']
         mid = href.split('/')[-1].replace('.asp?ID=', '-').split('&')[0]
         # e.g. VisNytFra-97
+        if not 'VisNytFra' in href:
+            continue
         skoleExamineNews(href, mid)
 
 


### PR DESCRIPTION
Fixed failure when fetching frontpage 'nyt fra' so that we only fetch VisNytFra messages.

This prevented an error for a frontpage with 'Driftsstatus'(opened in javascript window). This fix simply ignores messages like that so that we don't fail

Please merge this so that I can run the full script with the "DRIFTSSTATUS" on the frontpage in 'nyt fra' section
