### PR TITLE
Python3 support...or port?

### DIFF
--- a/skoleintra/config.py
+++ b/skoleintra/config.py
@@ -5,7 +5,8 @@ from __future__ import print_function
 
 import os
 import sys
-import ConfigParser
+import base64
+import configparser as ConfigParser
 import codecs
 import locale
 import getpass
@@ -77,7 +78,7 @@ def ensureDanish():
 
     enc = locale.getpreferredencoding() or 'ascii'
     test = u'\xe6\xf8\xe5\xc6\xd8\xc5\xe1'.encode(enc, 'replace')
-    if '?' in test or sys.version_info < (2, 6):
+    if '?' in test.decode("utf-8") or sys.version_info < (2, 6):
         sys.stderr = codecs.getwriter('UTF-8')(sys.stderr)
         sys.stdout = codecs.getwriter('UTF-8')(sys.stdout)
 ensureDanish()
@@ -104,7 +105,7 @@ def b64enc(pswd):
 
 def b64dec(pswd):
     assert(pswd.startswith('pswd:'))
-    return pswd[5:].decode('base64')
+    return base64.b64decode(pswd[5:]).decode('UTF-8')
 
 
 if options.doconfig:
@@ -187,7 +188,7 @@ if options.password is not None:
         cfg.set('default', 'password', pswd)
 
         data = open(CONFIG_FN, 'r').read()
-        r = re.compile(ur'(?m)^password\s*=.*$')
+        r = re.compile(r'(?m)^password\s*=.*$')
         if not r.findall(data):
             log(u'Kan ikke finde linjen med password', -2)
             log(u'Nyt kodeord bliver ikke skrevet i '

--- a/skoleintra/config.py
+++ b/skoleintra/config.py
@@ -1,7 +1,7 @@
-from __future__ import print_function
 #
 # -*- encoding: utf-8 -*-
 #
+from __future__ import print_function
 
 import os
 import sys

--- a/skoleintra/config.py
+++ b/skoleintra/config.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # -*- encoding: utf-8 -*-
 #
@@ -108,9 +109,9 @@ def b64dec(pswd):
 
 if options.doconfig:
     if os.path.isfile(CONFIG_FN):
-        print u'Din opsætning bliver nulstillet,',
-        print u'når du har besvareret nedenstående spørgsmål'
-    print u'Din nye opsætning gemmes her:', CONFIG_FN
+        print(u'Din opsætning bliver nulstillet,', end=' ')
+        print(u'når du har besvareret nedenstående spørgsmål')
+    print(u'Din nye opsætning gemmes her:', CONFIG_FN)
 
     details = {}
     opts = [
@@ -135,15 +136,15 @@ if options.doconfig:
          u'SMTP password (tom hvis login ikke påkrævet):')]
     for (var, question) in opts:
         while True:
-            print
-            print question
+            print()
+            print(question)
             if var.endswith('password'):
                 a = getpass.getpass('').strip().decode(sys.stdin.encoding)
             else:
                 a = raw_input().strip().decode(sys.stdin.encoding)
             if a or var.startswith('smtp'):
                 break
-            print u'Angiv venligst en værdi'
+            print(u'Angiv venligst en værdi')
         details[var] = a
 
     # "encrypt" the password
@@ -165,8 +166,8 @@ if options.doconfig:
         os.makedirs(ROOT)
     open(CONFIG_FN, 'w').write(config.encode('utf-8'))
 
-    print
-    print u'Din nye opsætning er klar -- kør nu programmet uden --config'
+    print()
+    print(u'Din nye opsætning er klar -- kør nu programmet uden --config')
     sys.exit(1)
 
 
@@ -223,7 +224,7 @@ try:
     SMTPPORT = softGet(cfg, 'default', 'smtpport')
     SMTPLOGIN = softGet(cfg, 'default', 'smtplogin')
     SMTPPASS = softGet(cfg, 'default', 'smtppassword')
-except ConfigParser.NoOptionError, e:
+except ConfigParser.NoOptionError as e:
     parser.error(u'''Konfigurationsfilen '%s' mangler en indstilling for %s.
 Kør først programmet med --config for at sætte det op.
 Eller ret direkte i '%s'.''' % (CONFIG_FN, e.option, CONFIG_FN))

--- a/skoleintra/config.py
+++ b/skoleintra/config.py
@@ -2,6 +2,10 @@
 # -*- encoding: utf-8 -*-
 #
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import hex
+from builtins import input
 
 import os
 import sys
@@ -142,7 +146,7 @@ if options.doconfig:
             if var.endswith('password'):
                 a = getpass.getpass('').strip().decode(sys.stdin.encoding)
             else:
-                a = raw_input().strip().decode(sys.stdin.encoding)
+                a = input().strip().decode(sys.stdin.encoding)
             if a or var.startswith('smtp'):
                 break
             print(u'Angiv venligst en værdi')

--- a/skoleintra/pgDialogue.py
+++ b/skoleintra/pgDialogue.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
 
 import re
-import config
-import surllib
-import semail
+from . import config
+from . import surllib
+from . import semail
 
 URL_PREFIX = '/Infoweb/Fi/Besked/'
 URL_BOX_PREFIX = URL_PREFIX + 'Oversigt.asp?Bakke='

--- a/skoleintra/pgDialogue.py
+++ b/skoleintra/pgDialogue.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
+from __future__ import absolute_import
 
 import re
 from . import config

--- a/skoleintra/pgDocuments.py
+++ b/skoleintra/pgDocuments.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
 
 import re
-import config
-import surllib
-import semail
+from . import config
+from . import surllib
+from . import semail
 import datetime
 import urllib
 
@@ -21,7 +22,7 @@ def docFindDocuments(bs, foldername='Dokumentarkiv'):
     trs = bs.findAll('tr')
 
     for line in trs:
-        if not line.has_key('class'):
+        if 'class' not in line:
             continue
         if not [c for c in line['class'].split() if c.startswith('linje')]:
             continue

--- a/skoleintra/pgDocuments.py
+++ b/skoleintra/pgDocuments.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
+from __future__ import absolute_import
 
 import re
 from . import config

--- a/skoleintra/pgDocuments.py
+++ b/skoleintra/pgDocuments.py
@@ -2,13 +2,16 @@
 # -*- encoding: utf-8 -*-
 #
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import map
 
 import re
 from . import config
 from . import surllib
 from . import semail
 import datetime
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 URL_PREFIX = 'http://%s/Infoweb/Fi/Dokumentarkiv/' % config.HOSTNAME
 URL_MAIN = URL_PREFIX + 'Dokliste.asp'
@@ -43,7 +46,7 @@ def docFindDocuments(bs, foldername='Dokumentarkiv'):
             url = URL_DOC + re.search('.*?(\d+)', links[0]['href']).group(1)
         else:
             assert('Dokliste' in url)
-        url = urllib.quote(url.encode('iso-8859-1'), safe=':/?=&%')
+        url = urllib.parse.quote(url.encode('iso-8859-1'), safe=':/?=&%')
 
         # find date
         dts = line.findAll('td', width='18%')
@@ -58,7 +61,7 @@ def docFindDocuments(bs, foldername='Dokumentarkiv'):
             suburl = URL_PREFIX + url
             subbs = surllib.skoleGetURL(suburl, True)
 
-            subdate = datetime.date(*reversed(map(int, date.split('-'))))
+            subdate = datetime.date(*reversed(list(map(int, date.split('-')))))
             if subbs.cachedate <= subdate or \
                (datetime.date.today() - subbs.cachedate).days > 2:
                 # cached version is too old - refetch

--- a/skoleintra/pgFrontpage.py
+++ b/skoleintra/pgFrontpage.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
 
-import config
-import surllib
-import semail
+from . import config
+from . import surllib
+from . import semail
 import re
 import BeautifulSoup
 
@@ -190,7 +191,7 @@ def skoleFrontpage():
     # find main table
     maint = []
     for mt in data.findAll('table'):
-        if mt.findParents('table') or mt.has_key('bgcolor'):
+        if mt.findParents('table') or 'bgcolor' in mt:
             continue
         maint.append(mt)
     assert(len(maint) == 1)  # assume exactly one main table

--- a/skoleintra/pgFrontpage.py
+++ b/skoleintra/pgFrontpage.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 #
 from __future__ import absolute_import
+from builtins import map
 
 from . import config
 from . import surllib
@@ -231,7 +232,7 @@ def skoleFrontpage():
             # BBB news are split
             # ignore first table which is a wrapper around all entries
             xs = xs[1:]
-            map(skoleFrontBBB, xs)
+            list(map(skoleFrontBBB, xs))
         elif t == TITLE_NEWS:
             # News from...
             skoleNewsFrom(xs)

--- a/skoleintra/pgFrontpage.py
+++ b/skoleintra/pgFrontpage.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
+from __future__ import absolute_import
 
 from . import config
 from . import surllib

--- a/skoleintra/pgWeekplans.py
+++ b/skoleintra/pgWeekplans.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
 
-import config
-import surllib
-import semail
+from . import config
+from . import surllib
+from . import semail
 import urllib
 
 URL_PREFIX = 'http://%s/Infoweb/Fi/' % config.HOSTNAME
@@ -27,7 +28,7 @@ def wpFindWeekplans(bs):
     trs = bs.findAll('tr')
 
     for line in trs:
-        if not line.has_key('class'):
+        if 'class' not in line:
             continue
         if not [c for c in line['class'].split() if c.startswith('linje')]:
             continue

--- a/skoleintra/pgWeekplans.py
+++ b/skoleintra/pgWeekplans.py
@@ -2,11 +2,13 @@
 # -*- encoding: utf-8 -*-
 #
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 
 from . import config
 from . import surllib
 from . import semail
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 URL_PREFIX = 'http://%s/Infoweb/Fi/' % config.HOSTNAME
 URL_MAIN = URL_PREFIX + 'Ugeplaner.asp'
@@ -42,7 +44,7 @@ def wpFindWeekplans(bs):
         # find url
         url = links[0]['href']
         url = url.encode('iso-8859-1')
-        url = URL_PREFIX + urllib.quote(url, safe=':/?=&%')
+        url = URL_PREFIX + urllib.parse.quote(url, safe=':/?=&%')
 
         bs = surllib.skoleGetURL(url, True)
         bs = wpTrimPlan(bs)

--- a/skoleintra/pgWeekplans.py
+++ b/skoleintra/pgWeekplans.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
+from __future__ import absolute_import
 
 from . import config
 from . import surllib

--- a/skoleintra/schildren.py
+++ b/skoleintra/schildren.py
@@ -1,8 +1,8 @@
-from __future__ import print_function
-from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
+from __future__ import print_function
+from __future__ import absolute_import
 
 from . import config
 from . import surllib

--- a/skoleintra/schildren.py
+++ b/skoleintra/schildren.py
@@ -1,9 +1,11 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
 
-import config
-import surllib
+from . import config
+from . import surllib
 
 URL_PREFIX = 'http://%s/Infoweb/Fi2/' % config.HOSTNAME
 URL = URL_PREFIX + 'Faneblade.asp'
@@ -47,7 +49,7 @@ def skoleSelectChild(name):
 
 if False:
     c = skoleGetChildren()
-    print repr(_children)
+    print(repr(_children))
     for cname in c:
-        print cname
+        print(cname)
         skoleSelectChild(cname)

--- a/skoleintra/semail.py
+++ b/skoleintra/semail.py
@@ -1,10 +1,10 @@
-from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
 # email validator
 # http://tools.ietf.org/tools/msglint/
 #
+from __future__ import absolute_import
 from . import config
 import md5
 import re

--- a/skoleintra/semail.py
+++ b/skoleintra/semail.py
@@ -5,6 +5,10 @@
 # http://tools.ietf.org/tools/msglint/
 #
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 from . import config
 import md5
 import re
@@ -18,7 +22,7 @@ import codecs
 import shutil
 import smtplib
 import mimetypes
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import imghdr
 
 import email
@@ -73,7 +77,7 @@ def generateMIMEAttachment(path, data, usefilename=None):
     # do not do this here - already done above.
     # encoders.encode_base64(msg)
     # Set the filename parameter
-    if type(fn) != unicode:
+    if type(fn) != str:
         fn = fn.decode('utf-8')
     fne = headerEncodeField(fn)
     msg.add_header('Content-Disposition', 'attachment', filename=fne)
@@ -81,7 +85,7 @@ def generateMIMEAttachment(path, data, usefilename=None):
     return msg
 
 
-class Message:
+class Message(object):
 
     def __init__(self, type, phtml):
         self.mp = {}
@@ -142,7 +146,7 @@ class Message:
             d = phtml.renderContents().decode('utf-8')
         else:
             d = self.mp['data']
-        assert(type(d) == unicode)  # must be unicode
+        assert(type(d) == str)  # must be unicode
 
         # e.g. front page pics
         m = re.findall(u'>(?:Lagt ind|Skrevet) af ([^<]*?) den ([-0-9]*?)<', d)
@@ -174,7 +178,7 @@ class Message:
         if not self.mp.get('md5', None):
             keys = 'type,date,title,data'.split(',')
             txt = u' '.join([self.mp[x] for x in keys if self.mp.get(x, None)])
-            self.mp['md5'] = unicode(md5.md5(txt.encode('utf-8')).hexdigest())
+            self.mp['md5'] = str(md5.md5(txt.encode('utf-8')).hexdigest())
 
         if not self.mp.get('date', None):
             # use today as the date
@@ -218,7 +222,7 @@ class Message:
         fd.write(str(self.asEmail()))
         fd.close()
 
-        mpp = [(unicode(k), unicode(v)) for (k, v) in self.mp.items()]
+        mpp = [(str(k), str(v)) for (k, v) in list(self.mp.items())]
         fd = codecs.open(os.path.join(tdn, mid + '.txt'), 'wb', 'utf-8')
         fd.write(repr(mpp))
         fd.close()
@@ -285,7 +289,7 @@ class Message:
             if url not in iimgs:
                 try:
                     data = surllib.skoleGetURL(url, False)
-                except urllib2.URLError as e:
+                except urllib.error.URLError as e:
                     # could not fetch URL for some reason - ignore
                     continue
                 # is this actually an image?
@@ -353,7 +357,7 @@ class Message:
             msg.attach(msgHtml)
 
             # attach images if any
-            for (url, (cid, data)) in iimgs.items():
+            for (url, (cid, data)) in list(iimgs.items()):
                 m = MIMEImage(data)
                 m.add_header('Content-ID', '<%s>' % cid)
                 fn = os.path.basename(url).encode('utf-8')

--- a/skoleintra/semail.py
+++ b/skoleintra/semail.py
@@ -1,15 +1,16 @@
+from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
 # email validator
 # http://tools.ietf.org/tools/msglint/
 #
-import config
+from . import config
 import md5
 import re
 import socket
 import BeautifulSoup
-import surllib
+from . import surllib
 import time
 import os
 import glob
@@ -284,7 +285,7 @@ class Message:
             if url not in iimgs:
                 try:
                     data = surllib.skoleGetURL(url, False)
-                except urllib2.URLError, e:
+                except urllib2.URLError as e:
                     # could not fetch URL for some reason - ignore
                     continue
                 # is this actually an image?
@@ -319,7 +320,7 @@ class Message:
                                (self.mp['title'] if self.mp['title'] else self,
                                 url))
                 if data:
-                    if atag.has_key('usefilename'):
+                    if 'usefilename' in atag:
                         usefilename = atag['usefilename']
                     else:
                         usefilename = None

--- a/skoleintra/surllib.py
+++ b/skoleintra/surllib.py
@@ -2,13 +2,16 @@
 # -*- encoding: utf-8 -*-
 #
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import hex
 
-import cookielib
-import urllib
+import http.cookiejar
+import urllib.request, urllib.parse, urllib.error
 from . import config
 import mechanize
 import BeautifulSoup
-import urlparse
+import urllib.parse
 import cgi
 import os
 import sys
@@ -33,7 +36,7 @@ def getBrowser():
         _browser = mechanize.Browser()
 
         # Cookie Jar
-        cj = cookielib.LWPCookieJar()
+        cj = http.cookiejar.LWPCookieJar()
         _browser.set_cookiejar(cj)
 
         # Browser options
@@ -122,11 +125,11 @@ def skoleLogin():
 
 def url2cacheFileName(url):
     assert(type(url) == str)
-    up = urlparse.urlparse(url)
+    up = urllib.parse.urlparse(url)
     parts = [config.CACHE_DN,
              up.scheme,
              up.netloc,
-             urllib.url2pathname(up.path)[1:]]
+             urllib.request.url2pathname(up.path)[1:]]
     if up.query:
         az = re.compile(r'[^0-9a-zA-Z]')
         for (k, vs) in sorted(cgi.parse_qs(up.query).items()):
@@ -137,7 +140,7 @@ def url2cacheFileName(url):
 
 def skoleGetURL(url, asSoup=False, noCache=False):
     '''Returns data from url as raw string or as a beautiful soup'''
-    if type(url) == unicode:
+    if type(url) == str:
         url, uurl = url.encode('utf-8'), url
     else:
         uurl = url.decode('utf-8')
@@ -160,7 +163,7 @@ def skoleGetURL(url, asSoup=False, noCache=False):
         config.log('skoleGetURL: Henter fra cache %s' % uurl, 2)
         data = open(lfn, 'rb').read()
     else:
-        qurl = urllib.quote(url, safe=':/?=&%')
+        qurl = urllib.parse.quote(url, safe=':/?=&%')
         config.log(u'skoleGetURL: Trying to fetch %s' % qurl, 2)
         skoleLogin()
         br = getBrowser()

--- a/skoleintra/surllib.py
+++ b/skoleintra/surllib.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
 
 import cookielib
 import urllib
-import config
+from . import config
 import mechanize
 import BeautifulSoup
 import urlparse

--- a/skoleintra/surllib.py
+++ b/skoleintra/surllib.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import
 #
 # -*- encoding: utf-8 -*-
 #
+from __future__ import absolute_import
 
 import cookielib
 import urllib


### PR DESCRIPTION
Since I am having problems running python 2.7 on mac after openSSL/Yosemite update, I wanted to explore if I could convert the scripts to python 3 which apparently does not have the problem I describe in #15.

I need your input:

* should FSKIntra work both for python 2.7 and 3?

For now I will attempt to get this working 'on my machine' (where the script does not work in python 2.7). Also, I don't do a lot of python so it will be trial-and-error. 

I would love any contributions to the branch, making it work.


### Update: `mechanize`not working with python 3

I will have to look at alternatives. From what I read, I need to dig into candidates like 
* MechanicalSoup – https://github.com/hickford/MechanicalSoup
* RoboBrowser – https://github.com/jmcarp/robobrowser
* Scrapy – http://doc.scrapy.org/en/latest/

The [python3 branch of mechanize](https://github.com/adevore/mechanize/tree/python3) (in a fork) did not work for me. It failed with the following exception:
```
  File "fskintra.py", line 7, in <module>
    import skoleintra.pgDialogue
  File "/Users/jesper/src/fskintra/skoleintra/pgDialogue.py", line 8, in <module>
    from . import surllib
  File "/Users/jesper/src/fskintra/skoleintra/surllib.py", line 12, in <module>
    import mechanize
  File "/usr/local/lib/python3.4/site-packages/mechanize-0.2.6.dev20150301-py3.4.egg/mechanize/__init__.py", line 119, in <module>
ImportError: No module named '_version'
```
So I better give the first alternatives a shot.
