### PR TITLE
Coding: utf8 headers++

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,43 +99,11 @@ Cron-job
 Tilføj flg. linje til din crontab fil for at få programmet til at køre
 to gange dagligt:
 
-    PYTHONIOENCODING=UTF-8
     25 6,18 * * * /path/to/fskintra.py -q
 
 Ved at tilføje -q, får du kun en email, såfremt der er noget
 interessant at se (og ikke en email om, at fskintra har prøvet at
 finde noget nyt uden at gøre det).
-
-Linjen med PYTHONIOENCODING=UTF-8 er ikke altid nødvendig (se evt. nedenfor),
-men er næsten altid en god idé.
-
-Problemer?
-----------
-
-**UnicodeEncodeError**
-I nogle situationer giver Python desværre en unicode-fejl lignende følgende
-
-    Traceback (most recent call last):
-      File "/home/user/fsk/fskintra.py", line 12, in <module>
-        cnames = skoleintra.schildren.skoleGetChildren()
-      File "/home/user/fsk/skoleintra/schildren.py", line 22, in skoleGetChildren
-        config.log(u'Henter liste af bM-CM-8rn')
-      File "/home/user/fsk/skoleintra/config.py", line 185, in log
-        sys.stderr.write(u'%s\n' % s)
-    UnicodeEncodeError: 'ascii' codec can't encode character u'\xf8' in position 17: ordinal not in range(128)
-
-En løsning vil i næsten alle tilfælde være at sætte miljøvariablen PYTHONIOENCODING til UTF-8.
-
-Hvis du bruger bash eller lignende (hvis du ikke ved, om du gør, så gør
-du sikkert).
-
-    export PYTHONIOENCODING=UTF-8
-    /sti/til/fskintra
-
-Hvis du bruger tcsh eller lignende:
-
-    setenv PYTHONIOENCODING UTF-8
-    /sti/til/fskintra
 
 **HTTP/HTML fejl**
 Den nuværende version af fskintra er ikke altid god til at håndtere

--- a/README.md
+++ b/README.md
@@ -99,11 +99,43 @@ Cron-job
 Tilføj flg. linje til din crontab fil for at få programmet til at køre
 to gange dagligt:
 
+    PYTHONIOENCODING=UTF-8
     25 6,18 * * * /path/to/fskintra.py -q
 
 Ved at tilføje -q, får du kun en email, såfremt der er noget
 interessant at se (og ikke en email om, at fskintra har prøvet at
 finde noget nyt uden at gøre det).
+
+Linjen med PYTHONIOENCODING=UTF-8 er ikke altid nødvendig (se evt. nedenfor),
+men er næsten altid en god idé.
+
+Problemer?
+----------
+
+**UnicodeEncodeError**
+I nogle situationer giver Python desværre en unicode-fejl lignende følgende
+
+    Traceback (most recent call last):
+      File "/home/user/fsk/fskintra.py", line 12, in <module>
+        cnames = skoleintra.schildren.skoleGetChildren()
+      File "/home/user/fsk/skoleintra/schildren.py", line 22, in skoleGetChildren
+        config.log(u'Henter liste af bM-CM-8rn')
+      File "/home/user/fsk/skoleintra/config.py", line 185, in log
+        sys.stderr.write(u'%s\n' % s)
+    UnicodeEncodeError: 'ascii' codec can't encode character u'\xf8' in position 17: ordinal not in range(128)
+
+En løsning vil i næsten alle tilfælde være at sætte miljøvariablen PYTHONIOENCODING til UTF-8.
+
+Hvis du bruger bash eller lignende (hvis du ikke ved, om du gør, så gør
+du sikkert).
+
+    export PYTHONIOENCODING=UTF-8
+    /sti/til/fskintra
+
+Hvis du bruger tcsh eller lignende:
+
+    setenv PYTHONIOENCODING UTF-8
+    /sti/til/fskintra
 
 **HTTP/HTML fejl**
 Den nuværende version af fskintra er ikke altid god til at håndtere

--- a/fskintra.py
+++ b/fskintra.py
@@ -1,7 +1,5 @@
-#! /usr/bin/env python
-#
-#
-#
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import skoleintra.config
 import skoleintra.pgContactLists

--- a/skoleintra/__init__.py
+++ b/skoleintra/__init__.py
@@ -1,3 +1,1 @@
-#
-# -*- encoding: utf-8
-#
+# -*- coding: utf-8 -*-

--- a/skoleintra/config.py
+++ b/skoleintra/config.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 import os
 import sys
@@ -68,18 +66,6 @@ if options.doconfig and options.password is not None:
     parser.error(u'''--config og --password kan ikke bruges samtidigt''')
 
 SKIP_CACHE = options.skipcache
-
-
-def ensureDanish():
-    '''Ensure that we can do Danish letters on stderr, stdout by wrapping
-    them using codecs.getwriter if necessary'''
-
-    enc = locale.getpreferredencoding() or 'ascii'
-    test = u'\xe6\xf8\xe5\xc6\xd8\xc5\xe1'.encode(enc, 'replace')
-    if '?' in test or sys.version_info < (2, 6):
-        sys.stderr = codecs.getwriter('UTF-8')(sys.stderr)
-        sys.stdout = codecs.getwriter('UTF-8')(sys.stdout)
-ensureDanish()
 
 
 # logging levels:

--- a/skoleintra/config.py
+++ b/skoleintra/config.py
@@ -68,6 +68,18 @@ if options.doconfig and options.password is not None:
 SKIP_CACHE = options.skipcache
 
 
+def ensureDanish():
+    '''Ensure that we can do Danish letters on stderr, stdout by wrapping
+    them using codecs.getwriter if necessary'''
+
+    enc = locale.getpreferredencoding() or 'ascii'
+    test = u'\xe6\xf8\xe5\xc6\xd8\xc5\xe1'.encode(enc, 'replace')
+    if '?' in test or sys.version_info < (2, 6):
+        sys.stderr = codecs.getwriter('UTF-8')(sys.stderr)
+        sys.stdout = codecs.getwriter('UTF-8')(sys.stdout)
+ensureDanish()
+
+
 # logging levels:
 #  0 some important stuff (requires -q)
 #  1 requires one         (default value)

--- a/skoleintra/pgContactLists.py
+++ b/skoleintra/pgContactLists.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 import config
 import surllib

--- a/skoleintra/pgDialogue.py
+++ b/skoleintra/pgDialogue.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 import re
 import config

--- a/skoleintra/pgDocuments.py
+++ b/skoleintra/pgDocuments.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 import re
 import config

--- a/skoleintra/pgFrontpage.py
+++ b/skoleintra/pgFrontpage.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 import config
 import surllib

--- a/skoleintra/pgWeekplans.py
+++ b/skoleintra/pgWeekplans.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 import config
 import surllib

--- a/skoleintra/schildren.py
+++ b/skoleintra/schildren.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 import config
 import surllib

--- a/skoleintra/semail.py
+++ b/skoleintra/semail.py
@@ -1,5 +1,5 @@
-#
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
+
 #
 # email validator
 # http://tools.ietf.org/tools/msglint/

--- a/skoleintra/sslfix.py
+++ b/skoleintra/sslfix.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 #
 # Fix (Mac) HTTPS (SSL) issues

--- a/skoleintra/surllib.py
+++ b/skoleintra/surllib.py
@@ -1,6 +1,4 @@
-#
-# -*- encoding: utf-8 -*-
-#
+# -*- coding: utf-8 -*-
 
 import cookielib
 import urllib


### PR DESCRIPTION
Til LektieWeb delen (branchen lektier) løb jeg ind i at blot en kommentar med # æøå fik apache til at give nedenstående fejl (på trods af PYTHONIOENCODING variablen var sat i /etc/apache/envvars):
AH01215: SyntaxError: Non-ASCII character '\xc3' in file /xxx on line 48, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

Hvad jeg har kunnet finde frem til er at der ikke skal stå encoding: med coding:
Derforuden skal det vist også stå længere oppe, så nu står de for lektiedelens vedkommende på 1. eller 2. linie afh. af om der shebang på 1. linie eller ej.

Derfor har jeg kunnet smide ensure_danish() (som jeg har kopieret til LektieWeb toppen) samt PYTHONIOENCODING variablen ud.
Endelig er det ikke nødvendigt med u'æøå', men 'æøå' er ok (men ikke ændret).

Test:
Det ser ud til at virke, jeg har gjort flg.:
- Kørt med -vv for at få noget log ud
- Kørt både manuelt og via cron med og uden ekstra -vv (normalt kører jeg ,med -q, så det blev -q -vvv)
  Resultat: Ingen fejl fundet.

Senere har jeg set en fejl, så jeg har genindsat PYTHONIOENCODING. => Jeg har ikke set nogle fejl.
Endelig har jeg genindsat ensureDanish, bare for at være sikker.
