### PR TITLE
better error handling of empty object in the document section

### DIFF
--- a/skoleintra/pgDocuments.py
+++ b/skoleintra/pgDocuments.py
@@ -23,8 +23,16 @@ def docFindDocuments(cname, rootTitle, bs, title):
                 (folder, len(docs)))
 
     for doc in docs:
-        docTitle = doc.find('span', 'sk-documents-document-title').text.strip()
-        docDate = doc.find('div', 'sk-documents-date-column').text.strip()
+        if doc.find('span', 'sk-documents-document-title') is not None:
+            docTitle = doc.find('span', 'sk-documents-document-title').text.strip()
+        else:
+            continue
+            
+        if doc.find('div', 'sk-documents-date-column') is not None:
+            docDate = doc.find('div', 'sk-documents-date-column').text.strip()
+        else:
+            continue
+
         a = doc.find('a')
         url = a and a['href'] or ''
         if '.' in docTitle:


### PR DESCRIPTION
Had a runtime error when fetching documents. Seems there's an empty object, as I am met with
```
https://www.google.com/search?client=safari&rls=en&q=AttributeError%3A+%27NoneType%27+object+has+no+attribute+%27text%27&ie=UTF-8&oe=UTF-8
```

This change will simply skip when no object are found by `doc.find('div', 'sk-documents-date-column')`.